### PR TITLE
fix emailConf.py error

### DIFF
--- a/config/emailConf.py
+++ b/config/emailConf.py
@@ -2,7 +2,7 @@
 __author__ = 'MR.wen'
 from email.header import Header
 from email.mime.text import MIMEText
-from config.ticketConf import _get_yaml
+from ticketConf import _get_yaml
 import smtplib
 
 


### PR DESCRIPTION
File "config/emailConf.py", line 5, in <module>
    from config.ticketConf import _get_yaml
ImportError: No module named config.ticketConf