### PR TITLE
docker优化

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+    12306ticket:
+        # image: 
+        build: .
+        # ports:
+        volumes:
+            - ./:/usr/src/app
+        container_name: 12306ticket
+
+


### PR DESCRIPTION
增加docker-compose 文件，可以通过一行命令
`docker-compose up`
来启动脚本容器，而不是通过原始的docker build -t . && docker run ***等复杂的命令。
可以通过`docker-compose up -d`来实现后台抢。需要docker-compose 环境，如果有docker，则只需`pip install docker-compose`即可，简化环境运行。如果可以建议在requirement.txt加入docker-compose的环境。