### PR TITLE
Define raw_input() in Python 3

### DIFF
--- a/inter/GetRandCode.py
+++ b/inter/GetRandCode.py
@@ -7,7 +7,7 @@ from damatuCode.ruokuai import RClient
 try:
     raw_input      # Python 2
 except NameError:  # Python 3
-    raw_input = input  
+    raw_input = input
 
 
 def getRandCode(is_auto_code, auto_code_type, result):

--- a/inter/GetRandCode.py
+++ b/inter/GetRandCode.py
@@ -6,7 +6,7 @@ from damatuCode.ruokuai import RClient
 
 try:
     raw_input      # Python 2
-excpet NameError:  # Python 3
+except NameError:  # Python 3
     raw_input = input  
 
 

--- a/inter/GetRandCode.py
+++ b/inter/GetRandCode.py
@@ -4,6 +4,11 @@ from PIL import Image
 from config.ticketConf import _get_yaml
 from damatuCode.ruokuai import RClient
 
+try:
+    raw_input      # Python 2
+excpet NameError:  # Python 3
+    raw_input = input  
+
 
 def getRandCode(is_auto_code, auto_code_type, result):
     """


### PR DESCRIPTION
__raw_input()__ was removed in Python 3 in favor of a reworked version of __input()__.  This change ensures equivalent functionality in both Python 2 and Python 3.