### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/inter/GetPassengerDTOs.py
+++ b/inter/GetPassengerDTOs.py
@@ -3,6 +3,11 @@ from config.TicketEnmu import ticket
 from myException.PassengerUserException import PassengerUserException
 import wrapcache
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 class getPassengerDTOs:
     """


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a reworked version of __range()__.  This change ensures equivalent functionality in both Python 2 and Python 3.