### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/agency/cdn_utils.py
+++ b/agency/cdn_utils.py
@@ -7,10 +7,12 @@ import sys
 import csv
 import requests
 from config import urlConf
-if sys.version_info.major == 2:
+
+try:
     reload(sys)
     sys.setdefaultencoding('utf-8')
-
+except NameError:
+    pass
 
 class CDNProxy:
     def __init__(self, host=None):

--- a/init/select_ticket_info.py
+++ b/init/select_ticket_info.py
@@ -30,9 +30,12 @@ from myException.ticketIsExitsException import ticketIsExitsException
 from myException.ticketNumOutException import ticketNumOutException
 from myUrllib.httpUtils import HTTPClient
 from utils.timeUtil import time_to_minutes, minutes_to_time
-if sys.version_info.major == 2:
+
+try:
     reload(sys)
     sys.setdefaultencoding('utf-8')
+except NameError:
+    pass
 
 
 class select:


### PR DESCRIPTION
Follows the Python porting best practice [__use feature detection instead of version detection__](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).