### PR TITLE
修正查询余票时，不显示当前cdn轮询IP问题

### DIFF
--- a/inter/Query.py
+++ b/inter/Query.py
@@ -161,7 +161,7 @@ class query:
                                         }
                 else:
                     print(u"车次配置信息有误，或者返回数据异常，请检查 {}".format(station_ticket))
-        return {"code": ticket.FAIL_CODE, "status": False}
+        return {"code": ticket.FAIL_CODE, "status": False, "cdn": self.httpClint.cdn,}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
修正查询余票时，不显示当前cdn轮询IP问题，更正一处逻辑错误。望接纳