### PR TITLE
对linux的安装依赖做了特别说明。

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 - 依赖库
   - 依赖若快 若快注册地址：http://www.ruokuai.com/client/index?6726 推荐用若快，打码兔平台已经关闭
   - 项目依赖包 requirements.txt
-  - 安装方法 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
+  - 安装方法-Windows: pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
+  - 安装方法-Linux:
+      - root用户(避免多python环境产生问题): python2 -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
+      - 非root用户（避免安装和运行时使用了不同环境）: sudo python2 -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
 
 - 项目使用说明
   - 需要配置邮箱，可以配置可以不配置，配置邮箱的格式在yaml里面可以看到ex


### PR DESCRIPTION
1.使用 `python2 -m pip install ...`的形式安装依赖可以避免多版本python、pip下的冲突问题，否则有可能会出现将依赖安装到python3上，项目无法运行的情况。
2.对root用户和非root用户做了区分。当非root用户直接使用`pip install ...`命令安装时，依赖会安装到当前用户目录下，但运行项目使用的是`sudo python run.py`，读取的是root用户目录下的依赖，可能会导致项目运行失败。