### PR TITLE
macos系统下使用docker容器运行sudo ./docker.sh run报错

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         # ports:
         volumes:
             - ./:/usr/src/app
-            - /etc/localtime:/etc/localtime:ro
+            #- /etc/localtime:/etc/localtime:ro
         container_name: 12306ticket
 
 


### PR DESCRIPTION
不注释的话，会报错，/etc/localtime 没有加入docker sharing ；加入docker sharing后又会报错：Cannot start service ticket：error while creating mount source path '/etc/localtime': mkdir /etc/localtime: file exists，注释掉后正常启动