### PR TITLE
macos上docker容器运行sudo ./docker.sh run报错

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         # ports:
         volumes:
             - ./:/usr/src/app
-            - /etc/localtime:/etc/localtime:ro
+            #- /etc/localtime:/etc/localtime:ro
         container_name: 12306ticket
 
 


### PR DESCRIPTION
在macos上不注释的话，会报错，/etc/localtime 未加入docker sharing ，将/etc/localtime 加入docker sharing后又会报错：Cannot start service ticket：error while creating mount source path '/etc/localtime': mkdir /etc/localtime: file exists，注释后可正常启动