### PR TITLE
Avoid reading ticket config file encoding error.

### DIFF
--- a/config/logger.py
+++ b/config/logger.py
@@ -44,7 +44,7 @@ def log(msg, func = "info"):
 		setDateStr(todayStr)
 		logger.removeHandler(loggerHandler)
 		
-		fh = logging.FileHandler(getLogFile())
+		fh = logging.FileHandler(getLogFile(), encoding = 'utf-8')
 		fm = logging.Formatter(u'[%(asctime)s][%(levelname)8s] --- %(message)s (%(filename)s:%(lineno)s)')
 		fh.setFormatter(fm)
 

--- a/config/ticketConf.py
+++ b/config/ticketConf.py
@@ -10,7 +10,7 @@ def _get_yaml():
     :return: s  字典
     """
     path = os.path.join(os.path.dirname(__file__) + '/ticket_config.yaml')
-    f = open(path, encoding = "utf8")
+    f = open(path, encoding = 'utf-8')
     s = yaml.load(f)
     f.close()
     return s.decode() if isinstance(s, bytes) else s

--- a/config/ticketConf.py
+++ b/config/ticketConf.py
@@ -10,7 +10,7 @@ def _get_yaml():
     :return: s  字典
     """
     path = os.path.join(os.path.dirname(__file__) + '/ticket_config.yaml')
-    f = open(path)
+    f = open(path, encoding = "utf8")
     s = yaml.load(f)
     f.close()
     return s.decode() if isinstance(s, bytes) else s

--- a/init/select_ticket_info.py
+++ b/init/select_ticket_info.py
@@ -130,7 +130,7 @@ class select:
         :return:
         """
         path = os.path.join(os.path.dirname(__file__), '../station_name.txt')
-        result = open(path)
+        result = open(path, encoding = 'utf-8')
         info = result.read().split('=')[1].strip("'").split('@')
         del info[0]
         station_name = {}


### PR DESCRIPTION
Avoid reading ticket config file encoding error: 
`TypeError: load() got an unexpected keyword argument 'encoding'`