### PR TITLE
更新余票查询地址

### DIFF
--- a/init/select_ticket_info.py
+++ b/init/select_ticket_info.py
@@ -53,7 +53,7 @@ class select:
         self.urls = urlConf.urls
         self.login = GoLogin(self, self.is_auto_code, self.auto_code_type)
         self.cdn_list = []
-        self.queryUrl = "leftTicket/queryZ"
+        self.queryUrl = "leftTicket/query"
         self.passengerTicketStrList = ""
         self.oldPassengerStr = ""
         self.set_type = ""


### PR DESCRIPTION
最新的12306已经将地址从 'queryz' 改为 'query'，这里做一下更新。不然会一直报 ip 错误。
修改之前：
<img width="1437" alt="屏幕快照 2019-03-26 下午10 51 27" src="https://user-images.githubusercontent.com/9377192/55007113-d2a5da80-5019-11e9-94c0-752ccdd025f4.png">
修改后：
<img width="1017" alt="屏幕快照 2019-03-26 下午10 51 18" src="https://user-images.githubusercontent.com/9377192/55007124-d6d1f800-5019-11e9-9f62-442d99dd7d22.png">
