### PR TITLE
fix warning:YAMLLoadWarning: calling yaml.load() without Loader=... i…

### DIFF
--- a/config/ticketConf.py
+++ b/config/ticketConf.py
@@ -14,10 +14,10 @@ def _get_yaml():
     path = os.path.join(os.path.dirname(__file__) + '/ticket_config.yaml')
     try:  # 兼容2和3版本
         with open(path, encoding="utf-8") as f:
-            s = yaml.load(f)
+            s = yaml.load(f, Loader=yaml.FullLoader)
     except Exception:
         with open(path) as f:
-            s = yaml.load(f)
+            s = yaml.load(f, Loader=yaml.FullLoader)
     return s.decode() if isinstance(s, bytes) else s
 
 


### PR DESCRIPTION
…s deprecated, as the default Loader is unsafe