### PR TITLE
增加了serverChan推送，希望多个选择

### DIFF
--- a/config/serverChanConf.py
+++ b/config/serverChanConf.py
@@ -1,0 +1,29 @@
+import time
+
+import requests
+#from config.ticketConf import _get_yaml
+from config.urlConf import urls
+from myUrllib.httpUtils import HTTPClient
+
+
+def sendServerChan(msg):
+    
+        try:
+            sendPushBearUrls = urls.get("ServerChan")
+            data = {
+                "text": "自定义购票成功通知测试版本",
+                "desp": msg
+            }
+            httpClint = HTTPClient(0)
+            sendPushBeaRsp = httpClint.send(sendPushBearUrls, data=data)
+            if sendPushBeaRsp.get("code") is 0:
+                print(u"已下发 serverChan 微信通知, 请查收")
+            else:
+                print(sendPushBeaRsp)
+        except Exception as e:
+            print(u"serverChan 配置有误 {}".format(e))
+        pass
+
+
+if __name__ == '__main__':
+    sendServerChan(1)

--- a/config/urlConf.py
+++ b/config/urlConf.py
@@ -408,6 +408,18 @@ urls = {
         "is_logger": False,
         "is_json": True,
     },
+	"ServerChan": {  # ServerChan通知,如果你的SCKEY是abcdefg，req_url配置成/abcdefg.send,如下
+        "req_url": "/abcdefg.send",
+        "req_type": "post",
+        "Referer": "",
+        "Content-Type": 1,
+        "Host": "sc.ftqq.com",
+        "re_try": 10,
+        "re_time": 0.01,
+        "s_time": 0.1,
+        "is_logger": False,
+        "is_json": True,
+    },
     "cdn_host": {
         "req_url": "http://ping.chinaz.com/kyfw.12306.cn",
         "req_type": "post"

--- a/inter/QueryOrderWaitTime.py
+++ b/inter/QueryOrderWaitTime.py
@@ -5,6 +5,7 @@ import time
 from config.TicketEnmu import ticket
 from config.emailConf import sendEmail
 from config.pushbearConf import sendPushBear
+from config.serverChanConf import sendServerChan
 from myException.ticketIsExitsException import ticketIsExitsException
 from myException.ticketNumOutException import ticketNumOutException
 
@@ -45,6 +46,7 @@ class queryOrderWaitTime:
                             data.get("orderId", "")))
                         sendPushBear(ticket.WAIT_ORDER_SUCCESS.format(
                             data.get("orderId", "")))
+                        sendServerChan(ticket.WAIT_ORDER_SUCCESS.format(data.get("orderId", "")))
                         raise ticketIsExitsException(ticket.WAIT_ORDER_SUCCESS.format(
                             data.get("orderId")))
                     elif data.get("msg", False):


### PR DESCRIPTION
**本人不会python**，pr只加了很少的代码，还是模仿作者写的。
不过我测试过了，购票成功可以通过推送。
登录server酱官网绑定微信后就会给你一个SCKEY，
然后将这个SCKEY填到urlConf.py文件里的serverChan下的req_url里就能使用了。
代码可能很烂，勿喷，我不会python