### PR TITLE
Fix the bug that can not run the getCookie.py in a command-line os

### DIFF
--- a/config/getCookie.py
+++ b/config/getCookie.py
@@ -9,7 +9,9 @@ def getDrvicesID(session):
     print("cookie获取中")
     from selenium import webdriver
     cookies = []
-    driver = webdriver.Chrome(TickerConfig.CHROME_PATH)
+    options = webdriver.ChromeOptions()
+    options.add_argument('headless')
+    driver = webdriver.Chrome(chrome_options=options, executable_path=TickerConfig.CHROME_PATH)
     driver.get("https://www.12306.cn/index/index.html")
     time.sleep(10)
     for c in driver.get_cookies():


### PR DESCRIPTION
在 没有图形界面的命令行操作系统中，由于getCookie.py 这个脚本运行Chrome 没有设置headless 运行，导致了错误。而且设置成headless还能提高运行速度，所以提个pr fix一下