### PR TITLE
fix a bug in cookie retrieval using chromedriver

### DIFF
--- a/config/getCookie.py
+++ b/config/getCookie.py
@@ -14,7 +14,11 @@ def getDrvicesID(session):
     if TickerConfig.COOKIE_TYPE is 1:
         from selenium import webdriver
         cookies = []
-        driver = webdriver.Chrome(executable_path=TickerConfig.CHROME_PATH)
+        option = webdriver.ChromeOptions()
+        option.add_argument('headless')
+        option.add_argument('no-sandbox')
+        option.add_argument('disable-dev-shm-usage')
+        driver = webdriver.Chrome(executable_path=TickerConfig.CHROME_PATH,chrome_options=option)
         driver.get("https://www.12306.cn/index/index.html")
         time.sleep(10)
         for c in driver.get_cookies():


### PR DESCRIPTION
python3.7.3+chrome76

**************************************************
cookie获取中
Traceback (most recent call last):
  File "run.py", line 20, in <module>
    run()
  File "run.py", line 8, in run
    select_ticket_info.select().main()
  File "/home/king/source/12306/init/select_ticket_info.py", line 155, in main
    getDrvicesID(self)
  File "/home/king/source/12306/config/getCookie.py", line 17, in getDrvicesID
    driver = webdriver.Chrome(executable_path=TickerConfig.CHROME_PATH)
  File "/home/king/.local/lib/python3.7/site-packages/selenium/webdriver/chrome/webdriver.py", line 75, in __init__
    desired_capabilities=desired_capabilities)
  File "/home/king/.local/lib/python3.7/site-packages/selenium/webdriver/remote/webdriver.py", line 154, in __init__
    self.start_session(desired_capabilities, browser_profile)
  File "/home/king/.local/lib/python3.7/site-packages/selenium/webdriver/remote/webdriver.py", line 243, in start_session
    response = self.execute(Command.NEW_SESSION, parameters)
  File "/home/king/.local/lib/python3.7/site-packages/selenium/webdriver/remote/webdriver.py", line 312, in execute
    self.error_handler.check_response(response)
  File "/home/king/.local/lib/python3.7/site-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.WebDriverException: Message: unknown error: Chrome failed to start: exited abnormally
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /usr/bin/chromium-browser is no longer running, so ChromeDriver is assuming that Chrome has crashed.)