### PR TITLE
使用配置文件配置云打码接口,提供云打码服务代码

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
          群里面也可以下载
       2. git仓库下载：https://github.com/testerSunshine/12306model.git
     ```
+  - 自托管云打码服务器搭建：[12306_code_server](https://github.com/YinAoXiong/12306_code_server)
   - 项目依赖包查看 [requirements.txt](requirements.txt)
   - 安装方法x:
       - root用户(避免多python环境产生问题): `pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt`

--- a/TickerConfig.py
+++ b/TickerConfig.py
@@ -57,6 +57,15 @@ IS_AUTO_CODE = True
 # ps: 请不要一直依赖云服务器资源，在此向提供服务器的"do it"同学表示感谢
 AUTO_CODE_TYPE = 3
 
+HOST="34.97.127.118:8000"
+REQ_URL="/verify/base64/"
+HTTP_TYPE="http"
+# HOST="12306.yinaoxiong.cn" #备用服务器稳定性较差
+# REQ_URL="/verify/base64/"
+# HTTP_TYPE="https"
+
+
+
 #  邮箱配置，如果抢票成功，将通过邮件配置通知给您
 #  列举163
 #  email: "xxx@163.com"

--- a/config/urlConf.py
+++ b/config/urlConf.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 import random
-
+import TickerConfig
 import time
 
 urls = {
@@ -588,15 +588,15 @@ urls = {
     },
 
     "autoVerifyImage": {  # 云打码接口
-        "req_url": "/verify/base64/",
+        "req_url": TickerConfig.REQ_URL,
         "req_type": "post",
         "Referer": "",
-        "Host": "34.97.127.118:8000",
+        "Host": TickerConfig.HOST,
         "re_try": 6,
         "re_time": 10,
         "s_time": 0.001,
         "is_logger": True,
         "is_json": True,
-        "httpType": "http"
+        "httpType": TickerConfig.HTTP_TYPE
     },
 }


### PR DESCRIPTION
使用配置文件配置云打码接口，可以更加灵活的进行选择，为 #446 写了一个多平台方便搭建云打码服务的仓库。

感觉要是大家有空闲的机器，作者可以维护一个可用云打码服务器列表让大家提交，然后供其他人进行选择。