### PR TITLE
增加Email配置端口选项

### DIFF
--- a/TickerConfig.py
+++ b/TickerConfig.py
@@ -78,6 +78,7 @@ HTTP_TYPE = "http"
 #  username: "xxxxx"
 #  password: "授权码"
 #  host: "smtp.qq.com"
+#  port: 25
 EMAIL_CONF = {
     "IS_MAIL": True,
     "email": "",
@@ -85,6 +86,7 @@ EMAIL_CONF = {
     "username": "",
     "password": "",
     "host": "smtp.qq.com",
+    "port": 25
 }
 
 # 是否开启 server酱 微信提醒， 使用前需要前往 http://sc.ftqq.com/3.version 扫码绑定获取 SECRET 并关注获得抢票结果通知的公众号

--- a/config/emailConf.py
+++ b/config/emailConf.py
@@ -21,6 +21,7 @@ def sendEmail(msg):
             username = TickerConfig.EMAIL_CONF["username"]
             password = TickerConfig.EMAIL_CONF["password"]
             host = TickerConfig.EMAIL_CONF["host"]
+            port = TickerConfig.EMAIL_CONF["port"]
             s = "{0}".format(msg)
 
             msg = MIMEText(s, 'plain', 'utf-8')  # 中文需参数‘utf-8’，单字节字符不需要
@@ -29,12 +30,12 @@ def sendEmail(msg):
             msg['To'] = receiver
 
             try:
-                smtp = smtplib.SMTP_SSL(host)
-                smtp.connect(host)
+                smtp = smtplib.SMTP_SSL(host, port)
+                smtp.connect(host, port)
             except socket.error:
                 smtp = smtplib.SMTP()
-                smtp.connect(host)
-            smtp.connect(host)
+                smtp.connect(host, port)
+            smtp.connect(host, port)
             smtp.login(username, password)
             smtp.sendmail(sender, receiver.split(","), msg.as_string())
             smtp.quit()


### PR DESCRIPTION
有些邮箱的SMTP服务使用的不是默认的25端口，比如我用的腾讯企业邮箱smtp.exmail.qq.com用的就是465端口