### PR TITLE
更新接口地址

### DIFF
--- a/init/select_ticket_info.py
+++ b/init/select_ticket_info.py
@@ -42,7 +42,9 @@ class select:
         self.login = GoLogin(self, TickerConfig.IS_AUTO_CODE, self.auto_code_type)
         self.cdn_list = []
         self.cookies = ""
-        self.queryUrl = "leftTicket/query"
+        # 此接口有变化，上官网点余票查询，按F12确定接口名称
+        # 19.12.14 目前使用接口为queryO
+        self.queryUrl = "leftTicket/queryO"
         self.passengerTicketStrList = ""
         self.passengerTicketStrByAfterLate = ""
         self.oldPassengerStr = ""


### PR DESCRIPTION
第一次尝试脚本，发现获取余票信息接口更新，不是/query，
改成了/queryO，也不是之前issue的/queryA。
若接口名称变化频率较高，是否考虑写进readme允许自由配置？