### PR TITLE
解决Mac系统下ChromeDriver报错导致无法运行的问题

### DIFF
--- a/config/getCookie.py
+++ b/config/getCookie.py
@@ -4,6 +4,7 @@ import re
 import time
 import os
 import TickerConfig
+import platform
 from config.urlConf import urls
 
 
@@ -22,7 +23,12 @@ def getDrvicesID(session):
             options.binary_location = TickerConfig.CHROME_CHROME_PATH
             options.add_argument("--no-sandbox")
             options.add_argument("--headless")
-        driver = webdriver.Chrome(executable_path=TickerConfig.CHROME_PATH,chrome_options=options)
+        # 解决MAC系统下因上面一段代码报错无法运行的问题    
+        sys_str = platform.system()
+        if sys_str == "Darwin":
+            driver = webdriver.Chrome(executable_path=TickerConfig.CHROME_PATH)
+        else:
+            driver = webdriver.Chrome(executable_path=TickerConfig.CHROME_PATH,chrome_options=options)        
         driver.get("https://www.12306.cn/index/index.html")
         time.sleep(10)
         for c in driver.get_cookies():


### PR DESCRIPTION
解决某个commit导致Mac系统下ChromeDriver报错程序无法运行的问题
## issue
[selenium开启ChromeDriver失败] (https://github.com/testerSunshine/12306/issues/498)