### PR TITLE
预售时间阻塞失败 #603问题修复

### DIFF
--- a/TickerConfig.py
+++ b/TickerConfig.py
@@ -113,7 +113,7 @@ ORDER_MODEL = 1
 IS_PROXY = 0
 
 # 预售放票时间, 如果是捡漏模式，可以忽略此操作
-OPEN_TIME = "12:59:57"
+OPEN_TIME = "2019-12-25 12:59:57"
 # 1=使用selenium获取devicesID
 # 2=使用网页端/otn/HttpZF/logdevice获取devicesId，这个接口的算法目前可能有点问题，如果登录一直302的请改为配置1
 # 3=自己打开浏览器在headers-Cookies中抓取RAIL_DEVICEID和RAIL_EXPIRATION，这个就不用配置selenium

--- a/init/select_ticket_info.py
+++ b/init/select_ticket_info.py
@@ -136,8 +136,9 @@ class select:
             print(f"预售还未开始，阻塞中，预售时间为{TickerConfig.OPEN_TIME}, 当前时间为: {now.strftime('%H:%M:%S')}")
             sleep_time_s = 0.1
             sleep_time_t = 0.3
+            open_time = datetime.datetime.strptime(TickerConfig.OPEN_TIME, '%Y-%m-%d %H:%M:%S')
             # 测试了一下有微妙级的误差，应该不影响，测试结果：2019-01-02 22:30:00.004555，预售还是会受到前一次刷新的时间影响，暂时没想到好的解决方案
-            while now.strftime("%d:%H:%M:%S") < TickerConfig.OPEN_TIME:
+            while now < open_time:
                 now = datetime.datetime.now()
                 time.sleep(0.0001)
             print(f"预售开始，开启时间为: {now.strftime('%H:%M:%S')}")

--- a/init/select_ticket_info.py
+++ b/init/select_ticket_info.py
@@ -137,7 +137,7 @@ class select:
             sleep_time_s = 0.1
             sleep_time_t = 0.3
             # 测试了一下有微妙级的误差，应该不影响，测试结果：2019-01-02 22:30:00.004555，预售还是会受到前一次刷新的时间影响，暂时没想到好的解决方案
-            while now.strftime("%H:%M:%S") < TickerConfig.OPEN_TIME:
+            while now.strftime("%d:%H:%M:%S") < TickerConfig.OPEN_TIME:
                 now = datetime.datetime.now()
                 time.sleep(0.0001)
             print(f"预售开始，开启时间为: {now.strftime('%H:%M:%S')}")


### PR DESCRIPTION
有如下两个改动点:
1. `OPEN_TIME`配置增加年月日；
2. `OPEN_TIME`格式化成`datetime`类型后，再和当前时间比较