### PR TITLE
修改urls["is_json"] 为true时，response非json格式bug，导致异常退出，使得用户一直 登陆不上bug。

### DIFF
--- a/myUrllib/httpUtils.py
+++ b/myUrllib/httpUtils.py
@@ -181,8 +181,12 @@ class HTTPClient(object):
                             logger.log(
                                 u"出参：{0}".format(response.content.decode()))
                         if urls["is_json"]:
-                            return json.loads(
-                                response.content.decode() if isinstance(response.content, bytes) else response.content)
+                            try:
+                                result = json.loads(
+                                    response.content.decode() if isinstance(response.content, bytes) else response.content)
+                            except:
+                                continue
+                            return result
                         else:
                             return response.content.decode("utf8", "ignore") if isinstance(response.content,
                                                                                            bytes) else response.content


### PR DESCRIPTION
比如打印response content内容： b'halo, world\n'
Traceback (most recent call last):
  File "run.py", line 22, in <module>
    select_ticket_info.select().main()
  File "/Users/sun/Documents/workspace/python/12306/init/select_ticket_info.py", line 123, in main
    self.call_login()
  File "/Users/sun/Documents/workspace/python/12306/init/select_ticket_info.py", line 117, in call_login
    self.login.go_login()
  File "/Users/sun/Documents/workspace/python/12306/init/login.py", line 129, in go_login
    uamtk = self.baseLogin(user, passwd)
  File "/Users/sun/Documents/workspace/python/12306/init/login.py", line 66, in baseLogin
    tresult = self.session.httpClint.send(logurl, loginData)
  File "/Users/sun/Documents/workspace/python/12306/myUrllib/httpUtils.py", line 187, in send
    response.content.decode() if isinstance(response.content, bytes) else response.content)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)